### PR TITLE
Admin and visitor account have default values

### DIFF
--- a/Backend/ResourceServer/ResourceServer/Controllers/VisitorAccountController.cs
+++ b/Backend/ResourceServer/ResourceServer/Controllers/VisitorAccountController.cs
@@ -20,30 +20,14 @@ namespace ResourceServer.Controller
         }
 
         [HttpPost]
-        public async Task<IActionResult> CreateVisitorAccount([FromBody] VisitorAccountDto visitorAccountDto)
+        public async Task<IActionResult> CreateVisitorAccount([FromBody] VisitorAccountDto dto)
         {
-            if (visitorAccountDto == null)
+            if (dto == null)
             {
                 return BadRequest("Invalid data.");
             }
 
-            //Hash password
-            var hashedPassword = Hasher.HashPassword(visitorAccountDto.Password);
-
-            var visitorAccount = new VisitorAccount
-            {
-                Id = Guid.NewGuid(),
-                Username = visitorAccountDto.UserName,
-                Password = hashedPassword,
-                StartDate = visitorAccountDto.StartDate,
-                EndDate = visitorAccountDto.EndDate,
-                PurposeTypeId = visitorAccountDto.PurposeTypeId,
-                VisitorId = visitorAccountDto.VisitorId,
-                AccountTypeId = visitorAccountDto.AccountTypeId
-            };
-
-            // Save the new visitor account 
-            await _visitorAccountRepository.CreateVisitorAccount(visitorAccount);
+            var visitorAccount = await _visitorAccountRepository.CreateVisitorAccount(dto);
             return Ok(visitorAccount);
         }
 

--- a/Backend/ResourceServer/ResourceServer/DTO/AdminDTO.cs
+++ b/Backend/ResourceServer/ResourceServer/DTO/AdminDTO.cs
@@ -1,9 +1,17 @@
-﻿namespace ResourceServer.DTO
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel;
+
+namespace ResourceServer.DTO
 {
     public class AdminDTO
     {
+        [DefaultValue("admin")]
         public string Username { get; set; }
+
+        [DefaultValue("password")]
         public string Password { get; set; }
+
+        [DefaultValue("36a817d3-4445-4779-a60b-23dc36d72cbf")] //Log admin
         public Guid AccountTypeId { get; set; }
     }
 }

--- a/Backend/ResourceServer/ResourceServer/DTO/VisitorAccountDto.cs
+++ b/Backend/ResourceServer/ResourceServer/DTO/VisitorAccountDto.cs
@@ -1,28 +1,31 @@
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-
+using System.ComponentModel;
 
 namespace ResourceServer.DTO
 {
     public class VisitorAccountDto
     {
-
         [Required]
         [StringLength(100, MinimumLength = 4)]
+        [DefaultValue("visitor")]
         public string UserName { get; set; }
 
         [StringLength(100, MinimumLength = 8)]
         [Required]
+        [DefaultValue("password")]
         public string Password { get; set; }
 
         public DateTime StartDate { get; set; }
 
         public DateTime EndDate { get; set; }
 
+        [DefaultValue("a98dc435-e2ce-4470-be62-bf58f677aec7")] //Service
         public Guid PurposeTypeId { get; set; }
 
+        [DefaultValue("a02cecf6-0749-48ba-bccd-f5871df211ab")] //Jane Smith
         public Guid? VisitorId { get; set; }
 
+        [DefaultValue("28633ad3-cce7-4cd5-85dd-5b27d93a60c9")] //Visitor account
         public Guid AccountTypeId { get; set; }
     }
 }

--- a/Backend/ResourceServer/ResourceServer/Repositories/IVisitorAccountRepository.cs
+++ b/Backend/ResourceServer/ResourceServer/Repositories/IVisitorAccountRepository.cs
@@ -7,8 +7,8 @@ namespace ResourceServer.Repositories
     {
         Task<IEnumerable<VisitorAccount>> GetAllVisitorAccounts();
         Task<VisitorAccount> GetVisitorAccountById(Guid id);
-        Task<VisitorAccount> UpdateVisitorAccount(Guid id, VisitorAccountDto visitorAccountDto);
-        Task<VisitorAccount> CreateVisitorAccount(VisitorAccount visitorAccount);
+        Task<VisitorAccount> UpdateVisitorAccount(Guid id, VisitorAccountDto dto);
+        Task<VisitorAccount> CreateVisitorAccount(VisitorAccountDto dto);
         Task DeleteVisitorAccount(int id);
     }
 }

--- a/Backend/ResourceServer/ResourceServer/Repositories/VisitorAccountRepository.cs
+++ b/Backend/ResourceServer/ResourceServer/Repositories/VisitorAccountRepository.cs
@@ -1,8 +1,8 @@
-using ResourceServer.Data;
-using SharedModels.Models;
 using Microsoft.EntityFrameworkCore;
+using ResourceServer.Data;
 using ResourceServer.DTO;
 using SharedModels.Hasher;
+using SharedModels.Models;
 
 namespace ResourceServer.Repositories
 {
@@ -17,8 +17,8 @@ namespace ResourceServer.Repositories
 
         public async Task<IEnumerable<VisitorAccount>> GetAllVisitorAccounts()
         {
-            return await _context.VisitorAccounts
-                .Include(v => v.Visitor) // Eagerly load the Visitor related entity
+            return await _context
+                .VisitorAccounts.Include(v => v.Visitor) // Eagerly load the Visitor related entity
                 .ToListAsync();
         }
 
@@ -27,7 +27,10 @@ namespace ResourceServer.Repositories
             return await _context.VisitorAccounts.FindAsync(id);
         }
 
-        public async Task<VisitorAccount> UpdateVisitorAccount(Guid id, VisitorAccountDto visitorAccountDto)
+        public async Task<VisitorAccount> UpdateVisitorAccount(
+            Guid id,
+            VisitorAccountDto dto
+        )
         {
             var visitorAccountToUpdate = await _context.VisitorAccounts.FindAsync(id);
 
@@ -36,22 +39,21 @@ namespace ResourceServer.Repositories
                 return null;
             }
 
-            var hashedPassword = Hasher.HashPassword(visitorAccountDto.Password);
-            
-            visitorAccountToUpdate.PurposeTypeId = visitorAccountDto.PurposeTypeId;
-            visitorAccountToUpdate.Username = visitorAccountDto.UserName;
+            var hashedPassword = Hasher.HashPassword(dto.Password);
+
+            visitorAccountToUpdate.PurposeTypeId = dto.PurposeTypeId;
+            visitorAccountToUpdate.Username = dto.UserName;
             visitorAccountToUpdate.Password = hashedPassword;
-            visitorAccountToUpdate.StartDate = visitorAccountDto.StartDate;
-            visitorAccountToUpdate.EndDate = visitorAccountDto.EndDate;
-            visitorAccountToUpdate.VisitorId = visitorAccountDto.VisitorId;
-            visitorAccountToUpdate.AccountTypeId = visitorAccountDto.AccountTypeId;
+            visitorAccountToUpdate.StartDate = dto.StartDate;
+            visitorAccountToUpdate.EndDate = dto.EndDate;
+            visitorAccountToUpdate.VisitorId = dto.VisitorId;
+            visitorAccountToUpdate.AccountTypeId = dto.AccountTypeId;
 
             _context.VisitorAccounts.Update(visitorAccountToUpdate);
             await _context.SaveChangesAsync();
 
             return visitorAccountToUpdate;
         }
-
 
         public async Task DeleteVisitorAccount(int id)
         {
@@ -63,8 +65,22 @@ namespace ResourceServer.Repositories
             }
         }
 
-        public async Task<VisitorAccount> CreateVisitorAccount(VisitorAccount visitorAccount)
+        public async Task<VisitorAccount> CreateVisitorAccount(VisitorAccountDto dto)
         {
+            var hashedPassword = Hasher.HashPassword(dto.Password);
+
+            var visitorAccount = new VisitorAccount
+            {
+                Id = Guid.NewGuid(),
+                Username = dto.UserName,
+                Password = hashedPassword,
+                StartDate = dto.StartDate,
+                EndDate = dto.EndDate,
+                PurposeTypeId = dto.PurposeTypeId,
+                VisitorId = dto.VisitorId,
+                AccountTypeId = dto.AccountTypeId
+            };
+
             _context.VisitorAccounts.Add(visitorAccount);
             await _context.SaveChangesAsync();
             return visitorAccount;


### PR DESCRIPTION
Added default values for purposetype, accounttype, username, password, and visitor id for visitor account and admin DTOs.
To not have to enter fields manually when testing with swagger
Also changed some structure between controller and repository for visitor account to be the same as the other endpoint methods
Renamed visitorAccountDto to dto