### PR TITLE
118 backend   add total objects return on get filtered statuses

### DIFF
--- a/Backend/ResourceServer/ResourceServer/Controllers/StatusController.cs
+++ b/Backend/ResourceServer/ResourceServer/Controllers/StatusController.cs
@@ -26,7 +26,7 @@ namespace ResourceServer.Controllers
         }
 
         [HttpGet("/filter")]
-        public async Task<ActionResult<IEnumerable<Status>>> GetFilteredStatuses(
+        public async Task<ActionResult<FilterReturnDTO>> GetFilteredStatuses(
             [FromQuery] int pageNumber,
             [FromQuery] int pageSize,
             [FromQuery] FilterDTO dto
@@ -78,13 +78,22 @@ namespace ResourceServer.Controllers
                 );
             }
 
+            //Get number of all elements
+            int totalSize = await filteredStatuses.CountAsync();
+
             //Pagination
             filteredStatuses = filteredStatuses.Skip((pageNumber - 1) * pageSize).Take(pageSize);
 
             //Database filtering and pagination executes
-            var statusList = await filteredStatuses.ToListAsync();
+            var filteredStatusList = await filteredStatuses.ToListAsync();
 
-            return Ok(statusList);
+            FilterReturnDTO returnDTO = new FilterReturnDTO
+            {
+                StatusList = filteredStatusList,
+                TotalNumberOfElements = totalSize,
+            };
+
+            return Ok(returnDTO);
         }
 
         [HttpPost]

--- a/Backend/ResourceServer/ResourceServer/Controllers/StatusController.cs
+++ b/Backend/ResourceServer/ResourceServer/Controllers/StatusController.cs
@@ -80,6 +80,7 @@ namespace ResourceServer.Controllers
 
             //Get number of all elements
             int totalSize = await filteredStatuses.CountAsync();
+            int totalPages = (int)Math.Ceiling((double)totalSize / pageSize); //Round up if it's a decimal number
 
             //Pagination
             filteredStatuses = filteredStatuses.Skip((pageNumber - 1) * pageSize).Take(pageSize);
@@ -91,6 +92,7 @@ namespace ResourceServer.Controllers
             {
                 StatusList = filteredStatusList,
                 TotalNumberOfElements = totalSize,
+                TotalNumberOfPages = totalPages
             };
 
             return Ok(returnDTO);

--- a/Backend/ResourceServer/ResourceServer/DTO/FilterReturnDTO.cs
+++ b/Backend/ResourceServer/ResourceServer/DTO/FilterReturnDTO.cs
@@ -6,5 +6,6 @@ namespace ResourceServer.DTO
     {
         public List<Status> StatusList { get; set; }
         public int TotalNumberOfElements { get; set; }
+        public int TotalNumberOfPages { get; set; }
     }
 }

--- a/Backend/ResourceServer/ResourceServer/DTO/FilterReturnDTO.cs
+++ b/Backend/ResourceServer/ResourceServer/DTO/FilterReturnDTO.cs
@@ -1,0 +1,10 @@
+using SharedModels.Models;
+
+namespace ResourceServer.DTO
+{
+    public class FilterReturnDTO
+    {
+        public List<Status> StatusList { get; set; }
+        public int TotalNumberOfElements { get; set; }
+    }
+}


### PR DESCRIPTION
- Added count on total number of elements and total number of pages
- Created new return type FilterReturnDTO

In frontend you can get
1) StatusList - the list with requested objects, filtered and/or paginated
2) TotalNumberOfElements - this value can be stored and sent in http request as pageSize when doing the CSV export
3) TotalNumberOfPages - to set up for navigation. For navigation in frontend display {pageNumber} / {TotalNumberOfPages}