### PR TITLE
 119-frontend---fix-the-correct-endpoints-for-fetching-pagnation-admin--visitor-account

### DIFF
--- a/Frontend/Visitation-logger-frontend/src/pages/accountManagement/index.jsx
+++ b/Frontend/Visitation-logger-frontend/src/pages/accountManagement/index.jsx
@@ -30,7 +30,6 @@ const AccountManagement = ({ isVisitor }) => {
   const [pageSize] = useState(10);
   const navigate = useNavigate();
 
-
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -109,7 +108,9 @@ const AccountManagement = ({ isVisitor }) => {
             onRowClick={handleRowClick}
           />
         ) : (
-          <div className="no-visitor-accounts">Inga besökarkonton hittades</div>
+          <div className="no-visitor-accounts">
+            {isNextDisabled ? "Finns inga fler konton" : "Inga konton hittades"}
+          </div>
         )}
 
         <div className="management-buttons-pagination">

--- a/Frontend/Visitation-logger-frontend/src/pages/accountManagement/index.jsx
+++ b/Frontend/Visitation-logger-frontend/src/pages/accountManagement/index.jsx
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 import Button from "../../components/button";
 import Table from "../../components/table";
 import {
-  getAllAdminAccounts,
-  getAllVisitorAccounts,
+  getAdminsByPage,
+  getVisitorAccountByPage,
 } from "../../services/apiClient";
 import "./accountManagement.css";
 import SearchBox from "../../components/searchBox";
@@ -24,15 +24,17 @@ const AccountManagement = ({ isVisitor }) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
+  const [pageNumber, setPageNumber] = useState(1);
+  const [pageSize] = useState(10);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         let result;
         if (isVisitor) {
-          result = await getAllVisitorAccounts();
+          result = await getVisitorAccountByPage(pageNumber, pageSize);
         } else {
-          result = await getAllAdminAccounts();
+          result = await getAdminsByPage(pageNumber, pageSize);
         }
         setData(result);
       } catch (error) {
@@ -43,7 +45,7 @@ const AccountManagement = ({ isVisitor }) => {
     };
 
     fetchData();
-  }, [isVisitor]);
+  }, [isVisitor, pageNumber, pageSize]);
 
   const handleSearchChange = (event) => {
     setSearchTerm(event.target.value);
@@ -62,6 +64,18 @@ const AccountManagement = ({ isVisitor }) => {
         .includes(searchTerm.toLowerCase())
     )
   );
+
+  const handleNextPage = () => {
+    setPageNumber((prev) => prev + 1);
+  };
+
+  const handlePrevPage = () => {
+    setPageNumber((prev) => prev - 1);
+  };
+
+  const isPrevDisabled = pageNumber === 1;
+
+  const isNextDisabled = filteredData.length === 0;
 
   if (loading) {
     return <LoadingCircle />; // Använd LoadingCircle-komponenten
@@ -97,15 +111,13 @@ const AccountManagement = ({ isVisitor }) => {
         <div className="management-buttons-pagination">
           <Button
             label={"Föregående"}
-            onClick={() => {
-              console.log("Klickat på föregående");
-            }}
+            onClick={handlePrevPage}
+            disabled={isPrevDisabled}
           />
           <Button
             label={"Nästa"}
-            onClick={() => {
-              console.log("Klickat på nästa");
-            }}
+            onClick={handleNextPage}
+            disabled={isNextDisabled}
           />
         </div>
       </div>

--- a/Frontend/Visitation-logger-frontend/src/services/apiClient.js
+++ b/Frontend/Visitation-logger-frontend/src/services/apiClient.js
@@ -12,15 +12,26 @@ async function getAllAdminAccounts() {
   return await get("Admin");
 }
 
+async function getAdminsByPage(pageNumber, pageSize) {
+  return await get("Admin/byPage", { pageNumber, pageSize });
+}
+
+async function getVisitorAccountByPage(pageNumber, pageSize) {
+  return await get("VisitorAccount/byPage", { pageNumber, pageSize });
+}
 async function post(endpoint, data, auth = true) {
   return await request("POST", endpoint, data, auth);
 }
 
-async function get(endpoint, auth = true) {
-  return await request("GET", endpoint, null, auth);
+async function get(endpoint, params = {}, auth = true) {
+  return await request("GET", endpoint, params, auth);
 }
 
 async function request(method, endpoint, data, auth = true) {
+  if (method.toUpperCase() === "GET" && data) {
+    const queryParams = new URLSearchParams(data).toString();
+    endpoint = `${endpoint}?${queryParams}`;
+  }
   const opts = {
     headers: {
       "Content-Type": "application/json",
@@ -45,4 +56,10 @@ async function request(method, endpoint, data, auth = true) {
   return response.json();
 }
 
-export { login, getAllVisitorAccounts, getAllAdminAccounts };
+export {
+  login,
+  getAllVisitorAccounts,
+  getAllAdminAccounts,
+  getAdminsByPage,
+  getVisitorAccountByPage,
+};


### PR DESCRIPTION
Now it will fetch all Admin accounts by pagenation and the same with visitor accounts, when pressing next or prev it will send in the next load to be viewed also added so that when we're at the first page the prev button is not clickable and if we have no data the next button is not clickable