### PR TITLE
Filter on substring

### DIFF
--- a/Backend/ResourceServer/ResourceServer/Controllers/StatusController.cs
+++ b/Backend/ResourceServer/ResourceServer/Controllers/StatusController.cs
@@ -40,9 +40,11 @@ namespace ResourceServer.Controllers
             var filteredStatuses = _statusRepository.GetAllStatusesForFiltering();
 
             //Filtering
-            if (dto.NodeId != null)
+            if (!string.IsNullOrEmpty(dto.NodeId))
             {
-                filteredStatuses = filteredStatuses.Where(status => status.NodeId == dto.NodeId);
+                filteredStatuses = filteredStatuses.Where(status =>
+                    status.NodeId.ToString().Contains(dto.NodeId)
+                );
             }
 
             if (
@@ -59,7 +61,7 @@ namespace ResourceServer.Controllers
 
                 filteredStatuses = filteredStatuses.Where(status =>
                     status.CheckInTime >= checkInTimeUtc
-                    // && !string.IsNullOrEmpty(status.CheckInSign)
+                // && !string.IsNullOrEmpty(status.CheckInSign)
                 );
             }
 
@@ -77,28 +79,32 @@ namespace ResourceServer.Controllers
 
                 filteredStatuses = filteredStatuses.Where(status =>
                     status.CheckOutTime >= checkOutTimeUtc
-                    // && !string.IsNullOrEmpty(status.CheckInSign)
+                // && !string.IsNullOrEmpty(status.CheckInSign)
                 );
             }
 
             if (!string.IsNullOrEmpty(dto.VisitorName))
             {
                 filteredStatuses = filteredStatuses.Where(status =>
-                    status.VisitorAccount.Visitor.FullName == dto.VisitorName
+                    status
+                        .VisitorAccount.Visitor.FullName.ToLower()
+                        .Contains(dto.VisitorName.ToLower())
                 );
             }
 
-            if (dto.VisitorId != null)
+            if (!string.IsNullOrEmpty(dto.VisitorId))
             {
                 filteredStatuses = filteredStatuses.Where(status =>
-                    status.VisitorAccount.Visitor.Id == dto.VisitorId
+                    status.VisitorAccount.Visitor.Id.ToString().Contains(dto.VisitorId)
                 );
             }
 
             if (!string.IsNullOrEmpty(dto.PurposeName))
             {
                 filteredStatuses = filteredStatuses.Where(status =>
-                    status.VisitorAccount.PurposeType.Name == dto.PurposeName
+                    status
+                        .VisitorAccount.PurposeType.Name.ToLower()
+                        .Contains(dto.PurposeName.ToLower())
                 );
             }
 

--- a/Backend/ResourceServer/ResourceServer/DTO/FilterDTO.cs
+++ b/Backend/ResourceServer/ResourceServer/DTO/FilterDTO.cs
@@ -3,9 +3,9 @@ namespace ResourceServer.DTO
     public class FilterDTO
     {
         public string? VisitorName { get; set; }
-        public Guid? VisitorId { get; set; }
+        public string? VisitorId { get; set; }
         public string? PurposeName { get; set; }
-        public Guid? NodeId { get; set; }
+        public string? NodeId { get; set; }
         public string? CheckInTime { get; set; } //Format yyyy-MM-dd
         public string? CheckOutTime { get; set; } //Format yyyy-MM-dd
         // public string? CheckInSign { get; set; }

--- a/Backend/SharedModels/SharedModels/Models/VisitorAccount.cs
+++ b/Backend/SharedModels/SharedModels/Models/VisitorAccount.cs
@@ -41,7 +41,6 @@ namespace SharedModels.Models
         public Guid AccountTypeId { get; set; }
 
         public virtual AccountType AccountType { get; set; }
-
        
         [Column("purpose_type_id")]
         [JsonIgnore]


### PR DESCRIPTION
Modified get all filtered statuses.
Added functionality to filter on substring of visitor id, visitor name, node id and purpose name.
Also added to be case insensitive.
For example: filter on "ja" for visitor name and all Jane, Janet, Javier etc. will be included

OBS the input data type of node id and visitor id are now strings, not guid. However the response is still the same with guid.